### PR TITLE
Configure output path with MAXMIND_DB_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Ensure your application has the latest copy of MaxMind data when deploying. Ideally, you should have a way to restart your application to make sure this build back happens often enough (if you deploy daily/weekly, you have nothing to worry about).
 
 ## How it Works
-The database file(s) is saved to a Heroku cache directory that is persisted across builds. If the database file does not exist, or is older than a week, a new copy is downloaded and moved to your project before deployment. All database files are stored in the root of your project when deployed.
+The database file(s) is saved to a Heroku cache directory that is persisted across builds. If the database file does not exist, or is older than a week, a new copy is downloaded and moved to your project before deployment. If MAXMIND_DB_DIR is set, database files are stored there when deployed. Otherwise, files are stored in the root of your project.
 
 ## Required Environment Variables
 * MAXMIND_KEY = The license key they provided which allows you to download files.

--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,7 @@ fi
 
 MAXMIND_KEY=`cat $ENV_DIR/MAXMIND_KEY`
 MAXMIND_EDITIONS=`cat $ENV_DIR/MAXMIND_EDITIONS`
+MAXMIND_DB_DIR=`cat $ENV_DIR/MAXMIND_DB_DIR`
 
 mkdir -p $CACHE_DIR
 
@@ -56,7 +57,7 @@ download(){
 		echo "-----> $EDITION: Database already exists in cache."
 	fi
 
-	OUTPUT="$BUILD_DIR/$SAVE"
+	OUTPUT="$BUILD_DIR/$MAXMIND_DB_DIR"
 
 	echo "-----> $EDITION: Copying $DB to $OUTPUT"
 


### PR DESCRIPTION
The original version saved all database files to the project root
directory. Now, MAXMIND_DB_DIR can be set to a path relative to the
project root, and files will be saved there instead.